### PR TITLE
Attempt to fix reported bug that I cannot recreate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "org.openstaxcollege.android"
         minSdkVersion 19
         targetSdkVersion 26
-        versionCode 33
-        versionName "5.6"
+        versionCode 34
+        versionName "5.7"
     }
     dependencies{
         implementation 'com.android.support:appcompat-v7:26.1.0'

--- a/app/src/main/java/org/openstaxcollege/android/activity/WebViewActivity.java
+++ b/app/src/main/java/org/openstaxcollege/android/activity/WebViewActivity.java
@@ -194,11 +194,12 @@ public class WebViewActivity extends AppCompatActivity implements FetchPdfUrlTas
             }
 
         }
-        new FetchPdfUrlTask(content.getBookTitle(), this).execute();
+
 
         if(OSCUtil.isConnected(this))
         {
             setUpViews();
+            new FetchPdfUrlTask(content.getBookTitle(), this).execute();
 
         }
         else

--- a/app/src/test/kotlin/org/openstaxcollege/android/test/FetchJsonTest.kt
+++ b/app/src/test/kotlin/org/openstaxcollege/android/test/FetchJsonTest.kt
@@ -22,7 +22,12 @@ class FetchJsonTest
         for(item in books.orEmpty())
         {
             println(item?.title)
-            println(item?.lowResolutionPdfUrl)
+            var pdf = item?.lowResolutionPdfUrl
+            if(pdf == null)
+            {
+                pdf = item?.highResolutionPdfUrl
+            }
+            println(pdf)
         }
 
     }

--- a/app/src/test/kotlin/org/openstaxcollege/android/test/WebviewLogicTest.kt
+++ b/app/src/test/kotlin/org/openstaxcollege/android/test/WebviewLogicTest.kt
@@ -15,7 +15,7 @@ class WebviewLogicTest
     fun testGetPdfUrl()
     {
         val webLogic = WebviewLogic()
-        val url:String = webLogic.getPDFUrl("Fizyka dla szkół wyższych Tom 1")
+        val url:String = webLogic.getPDFUrl("Fizyka dla szkół wyższyc. Tom 1")
         //val url:String = webLogic.getPDFUrl("College Physics")
         //val url:String = webLogic.getPDFUrl("Precalculus")
         //val url:String = webLogic.getPDFUrl("Chemistry: Atoms First")


### PR DESCRIPTION
Users are getting an IllegalStateException when app tries to retrieve the PDF URL from the OpenStax CMS. My best guess of the cause is a lack of a connection. I am now checking for a connection before fetching the PDF URL.